### PR TITLE
Add switch_offset config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Since toolchanging has no standardised approach in the Klipper world this is an 
 ## Config example
 
 ```yaml
+[offset_probe]
 # Define the pin that the extra probe is connected to
 pin: ^PC16
 # X,Y coordinates to probe - these should be the native coordinates before any offsets are applied
@@ -25,6 +26,9 @@ probe_x: 150
 probe_y: 150
 # Z offset of the Z limit switch, which will be added to the calculated offset
 z_offset: 0
+# Additional offset added to each determined tool offset to account for micro switch pre-travel
+# e.g. when using a removable hardware probe that utilises a micro switch to trigger
+switch_offset: 0
 # The speed (in mm/sec) to move tools down onto the probe
 speed: 5
 # The speed (in mm/sec) to retract between probes

--- a/offset_probe.py
+++ b/offset_probe.py
@@ -14,7 +14,6 @@ class OffsetProbe:
     self.name = config.get_name()
     self.mcu_probe = mcu_probe
 
-
     self.probe_x = config.getfloat('probe_x', 0.)
     self.probe_y = config.getfloat('probe_y', 0.)
 
@@ -23,6 +22,8 @@ class OffsetProbe:
     self.y_offset = config.getfloat('y_offset', 0.)
     # The trigger distance of the probe, the plunge height of a switch based probe
     self.z_offset = config.getfloat('z_offset', 0.)
+
+    self.switch_offset = config.getfloat('switch_offset', 0.)
 
     # The starting Z height when probing tools - all tools must be accurate to within this value
     self.tool_probe_z = config.getfloat('reprobe_height', 1., above=0.)
@@ -163,7 +164,7 @@ class OffsetProbe:
       toolhead.manual_move(coord, self.move_speed)
       # Probe and get the new offset
       z = self._accurate_probe(self.speed)
-      offsets.append(z - base_z)
+      offsets.append(z - base_z + self.switch_offset)
       # gcmd.respond_info('Tool %d: %.6f' % (i, z))
       self._lift_between_probes()
     


### PR DESCRIPTION
Add additional config option `switch_offset` which can be used to set an offset applied to each tool offset to account for removable probes that use a micro switch and thus have an amount of pre-travel before triggering.